### PR TITLE
Return `observation_driven` argument from `predict.threedx`

### DIFF
--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -258,6 +258,9 @@ plot_paths <- function(object,
                    "; seasonal: ", round(model$alpha_seasonal, 4),
                    "; decay: ", round(model$alpha_seasonal_decay, 4))
   
+  observation_driven <- paste0("Is observation-driven: ",
+                               object$observation_driven)
+  
   if (is.null(date) || is.null(date_future)) {
     date_label <- NA
     date <- 1:length(model$y)
@@ -272,6 +275,7 @@ plot_paths <- function(object,
   
   df_future <- data.frame(
     params = params,
+    observation_driven = observation_driven,
     date = rep(date_future, times = n),
     sample_index = rep(sample_idx, each = dim(paths)[1]),
     value = NA
@@ -285,6 +289,7 @@ plot_paths <- function(object,
   
   df_input <- data.frame(
     params = params,
+    observation_driven = observation_driven,
     date = date,
     value = model$y
   )
@@ -326,7 +331,7 @@ plot_paths <- function(object,
   }
   
   if (show_params) {
-    ggp <- ggp + ggplot2::facet_wrap(~ params)
+    ggp <- ggp + ggplot2::facet_wrap(~ params + observation_driven)
   }
   
   return(ggp)
@@ -419,16 +424,21 @@ plot_forecast <- function(object,
                    "; seasonal: ", round(model$alpha_seasonal, 4),
                    "; decay: ", round(model$alpha_seasonal_decay, 4))
   
+  observation_driven <- paste0("Is observation-driven: ",
+                               object$observation_driven)
+  
   df_input <- data.frame(
     date = date,
     value = model$y,
     weight = model$weights,
-    params = params
+    params = params,
+    observation_driven = observation_driven
   )
   
   df_future <- data.frame(
     date = date_future,
     params = params,
+    observation_driven = observation_driven,
     y_hat_1l = apply(paths, 1, stats::quantile, 0.5 / 12, na.rm = TRUE),
     y_hat_2l = apply(paths, 1, stats::quantile, 2 / 12, na.rm = TRUE),
     y_hat_3l = apply(paths, 1, stats::quantile, 3 / 12, na.rm = TRUE),
@@ -489,7 +499,7 @@ plot_forecast <- function(object,
   }
   
   if (show_params) {
-    ggp <- ggp + ggplot2::facet_wrap(~ params)
+    ggp <- ggp + ggplot2::facet_wrap(~ params + observation_driven)
   }
   
   return(ggp)

--- a/R/predict.R
+++ b/R/predict.R
@@ -71,7 +71,10 @@ predict.threedx <- function(object,
   result <- structure(
     list(
       paths = paths,
-      model = object
+      model = object,
+      horizon = horizon,
+      n_samples = n_samples,
+      observation_driven = observation_driven
     ),
     class = "threedx_paths"
   )

--- a/README.Rmd
+++ b/README.Rmd
@@ -77,3 +77,9 @@ When `ggplot2` is available, we can use `autoplot()` to visualize the forecast o
 library(ggplot2)
 autoplot(forecast)
 ```
+
+## References
+
+Alexander Alexandrov et al. (2019). *GluonTS: Probabilistic Time Series Models in Python*. https://arxiv.org/abs/1906.05264
+
+Jan Gasthaus (2016). *Non-parametric time series forecaster*. Technical report, Amazon, 2016.

--- a/README.md
+++ b/README.md
@@ -69,3 +69,11 @@ autoplot(forecast)
 ```
 
 <img src="man/figures/README-plot_forecast-1.svg" width="100%" />
+
+## References
+
+Alexander Alexandrov et al. (2019). *GluonTS: Probabilistic Time Series
+Models in Python*. <https://arxiv.org/abs/1906.05264>
+
+Jan Gasthaus (2016). *Non-parametric time series forecaster*. Technical
+report, Amazon, 2016.

--- a/man/figures/README-plot_forecast-1.svg
+++ b/man/figures/README-plot_forecast-1.svg
@@ -24,108 +24,115 @@
 <rect x='0.00' y='0.00' width='504.00' height='360.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
-  <clipPath id='cpMzMuNDd8NDk4LjUyfDIyLjY5fDMxNy44OA=='>
-    <rect x='33.47' y='22.69' width='465.05' height='295.19' />
+  <clipPath id='cpMzMuNDd8NDk4LjUyfDM5LjkwfDMxNy44OA=='>
+    <rect x='33.47' y='39.90' width='465.05' height='277.98' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzMuNDd8NDk4LjUyfDIyLjY5fDMxNy44OA==)'>
-<rect x='33.47' y='22.69' width='465.05' height='295.19' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
-<polyline points='33.47,267.19 498.52,267.19 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='33.47,192.65 498.52,192.65 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='33.47,118.10 498.52,118.10 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='33.47,43.56 498.52,43.56 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='112.26,317.88 112.26,22.69 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='240.37,317.88 240.37,22.69 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='368.49,317.88 368.49,22.69 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='496.60,317.88 496.60,22.69 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='33.47,304.46 498.52,304.46 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='33.47,229.92 498.52,229.92 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='33.47,155.37 498.52,155.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='33.47,80.83 498.52,80.83 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='48.20,317.88 48.20,22.69 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='176.32,317.88 176.32,22.69 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='304.43,317.88 304.43,22.69 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='432.54,317.88 432.54,22.69 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='54.61,229.92 61.01,125.56 67.42,51.01 73.83,140.47 80.23,200.10 86.64,304.46 93.04,304.46 99.45,289.55 105.85,304.46 112.26,289.55 118.67,289.55 125.07,289.55 131.48,155.37 137.88,140.47 144.29,185.19 150.69,170.28 157.10,229.92 163.50,274.64 169.91,304.46 176.32,304.46 182.72,304.46 189.13,304.46 195.53,304.46 201.94,289.55 208.34,274.64 214.75,140.47 221.16,155.37 227.56,140.47 233.97,215.01 240.37,274.64 246.78,304.46 253.18,304.46 259.59,304.46 266.00,304.46 272.40,304.46 278.81,304.46 285.21,215.01 291.62,185.19 298.02,36.11 304.43,140.47 310.83,244.82 317.24,304.46 323.65,304.46 330.05,304.46 336.46,304.46 342.86,304.46 349.27,304.46 355.67,274.64 362.08,259.73 368.49,95.74 374.89,80.83 381.30,140.47 387.70,200.10 394.11,274.64 400.51,304.46 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<circle cx='54.61' cy='229.92' r='1.42' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='61.01' cy='125.56' r='1.42' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='67.42' cy='51.01' r='1.42' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='73.83' cy='140.47' r='1.43' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='80.23' cy='200.10' r='1.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='86.64' cy='304.46' r='1.54' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='93.04' cy='304.46' r='1.81' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='99.45' cy='289.55' r='2.66' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='105.85' cy='304.46' r='1.84' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='112.26' cy='289.55' r='1.56' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='118.67' cy='289.55' r='1.47' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='125.07' cy='289.55' r='1.44' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='131.48' cy='155.37' r='1.43' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='137.88' cy='140.47' r='1.42' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='144.29' cy='185.19' r='1.43' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='150.69' cy='170.28' r='1.44' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='157.10' cy='229.92' r='1.48' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='163.50' cy='274.64' r='1.61' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='169.91' cy='304.46' r='2.05' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='176.32' cy='304.46' r='3.44' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='182.72' cy='304.46' r='2.10' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='189.13' cy='304.46' r='1.65' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='195.53' cy='304.46' r='1.50' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='201.94' cy='289.55' r='1.45' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='208.34' cy='274.64' r='1.43' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='214.75' cy='140.47' r='1.42' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='221.16' cy='155.37' r='1.43' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='227.56' cy='140.47' r='1.45' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='233.97' cy='215.01' r='1.52' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='240.37' cy='274.64' r='1.74' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='246.78' cy='304.46' r='2.44' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='253.18' cy='304.46' r='4.70' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='259.59' cy='304.46' r='2.52' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='266.00' cy='304.46' r='1.79' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='272.40' cy='304.46' r='1.55' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='278.81' cy='304.46' r='1.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='285.21' cy='215.01' r='1.44' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='291.62' cy='185.19' r='1.43' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='298.02' cy='36.11' r='1.44' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='304.43' cy='140.47' r='1.47' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='310.83' cy='244.82' r='1.58' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='317.24' cy='304.46' r='1.93' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='323.65' cy='304.46' r='3.07' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='330.05' cy='304.46' r='6.76' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='336.46' cy='304.46' r='3.21' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='342.86' cy='304.46' r='2.02' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='349.27' cy='304.46' r='1.62' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='355.67' cy='274.64' r='1.49' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='362.08' cy='259.73' r='1.44' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='368.49' cy='95.74' r='1.43' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='374.89' cy='80.83' r='1.45' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='381.30' cy='140.47' r='1.50' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='387.70' cy='200.10' r='1.68' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='394.11' cy='274.64' r='2.25' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<circle cx='400.51' cy='304.46' r='4.11' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
-<polygon points='406.92,304.46 413.33,304.46 419.73,304.46 426.14,274.64 432.54,259.73 438.95,95.74 445.35,80.83 451.76,36.11 458.16,80.83 464.57,140.47 470.98,200.10 477.38,274.64 477.38,304.46 470.98,304.46 464.57,274.64 458.16,215.01 451.76,215.01 445.35,274.64 438.95,304.46 432.54,304.46 426.14,304.46 419.73,304.46 413.33,304.46 406.92,304.46 ' style='stroke-width: 0.00; stroke: none; fill: #0000FF; fill-opacity: 0.16;' />
-<polyline points='406.92,304.46 413.33,304.46 419.73,304.46 426.14,274.64 432.54,259.73 438.95,95.74 445.35,80.83 451.76,36.11 458.16,80.83 464.57,140.47 470.98,200.10 477.38,274.64 ' style='stroke-width: 1.07; stroke: none;' />
-<polyline points='477.38,304.46 470.98,304.46 464.57,274.64 458.16,215.01 451.76,215.01 445.35,274.64 438.95,304.46 432.54,304.46 426.14,304.46 419.73,304.46 413.33,304.46 406.92,304.46 ' style='stroke-width: 1.07; stroke: none;' />
-<polygon points='406.92,304.46 413.33,304.46 419.73,304.46 426.14,304.46 432.54,274.64 438.95,215.01 445.35,95.74 451.76,51.01 458.16,140.47 464.57,140.47 470.98,244.82 477.38,304.46 477.38,304.46 470.98,304.46 464.57,244.82 458.16,140.47 451.76,155.37 445.35,215.01 438.95,274.64 432.54,304.46 426.14,304.46 419.73,304.46 413.33,304.46 406.92,304.46 ' style='stroke-width: 0.00; stroke: none; fill: #0000FF; fill-opacity: 0.16;' />
-<polyline points='406.92,304.46 413.33,304.46 419.73,304.46 426.14,304.46 432.54,274.64 438.95,215.01 445.35,95.74 451.76,51.01 458.16,140.47 464.57,140.47 470.98,244.82 477.38,304.46 ' style='stroke-width: 1.07; stroke: none;' />
-<polyline points='477.38,304.46 470.98,304.46 464.57,244.82 458.16,140.47 451.76,155.37 445.35,215.01 438.95,274.64 432.54,304.46 426.14,304.46 419.73,304.46 413.33,304.46 406.92,304.46 ' style='stroke-width: 1.07; stroke: none;' />
-<polygon points='406.92,304.46 413.33,304.46 419.73,304.46 426.14,304.46 432.54,274.64 438.95,215.01 445.35,95.74 451.76,80.83 458.16,140.47 464.57,200.10 470.98,274.64 477.38,304.46 477.38,304.46 470.98,304.46 464.57,244.82 458.16,140.47 451.76,140.47 445.35,185.19 438.95,259.73 432.54,304.46 426.14,304.46 419.73,304.46 413.33,304.46 406.92,304.46 ' style='stroke-width: 0.00; stroke: none; fill: #0000FF; fill-opacity: 0.16;' />
-<polyline points='406.92,304.46 413.33,304.46 419.73,304.46 426.14,304.46 432.54,274.64 438.95,215.01 445.35,95.74 451.76,80.83 458.16,140.47 464.57,200.10 470.98,274.64 477.38,304.46 ' style='stroke-width: 1.07; stroke: none;' />
-<polyline points='477.38,304.46 470.98,304.46 464.57,244.82 458.16,140.47 451.76,140.47 445.35,185.19 438.95,259.73 432.54,304.46 426.14,304.46 419.73,304.46 413.33,304.46 406.92,304.46 ' style='stroke-width: 1.07; stroke: none;' />
-<polyline points='406.92,304.46 413.33,304.46 419.73,304.46 426.14,304.46 432.54,274.64 438.95,259.73 445.35,95.74 451.76,80.83 458.16,140.47 464.57,200.10 470.98,274.64 477.38,304.46 ' style='stroke-width: 1.07; stroke: #00008B; stroke-linecap: butt;' />
-<circle cx='406.92' cy='304.46' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
-<circle cx='413.33' cy='304.46' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
-<circle cx='419.73' cy='304.46' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
-<circle cx='426.14' cy='304.46' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
-<circle cx='432.54' cy='274.64' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
-<circle cx='438.95' cy='259.73' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
-<circle cx='445.35' cy='95.74' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
-<circle cx='451.76' cy='80.83' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
-<circle cx='458.16' cy='140.47' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
-<circle cx='464.57' cy='200.10' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
-<circle cx='470.98' cy='274.64' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
-<circle cx='477.38' cy='304.46' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
+<g clip-path='url(#cpMzMuNDd8NDk4LjUyfDM5LjkwfDMxNy44OA==)'>
+<rect x='33.47' y='39.90' width='465.05' height='277.98' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='33.47,270.14 498.52,270.14 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='33.47,199.95 498.52,199.95 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='33.47,129.75 498.52,129.75 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='33.47,59.55 498.52,59.55 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='112.26,317.88 112.26,39.90 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='240.37,317.88 240.37,39.90 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='368.49,317.88 368.49,39.90 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='496.60,317.88 496.60,39.90 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='33.47,305.24 498.52,305.24 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='33.47,235.04 498.52,235.04 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='33.47,164.85 498.52,164.85 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='33.47,94.65 498.52,94.65 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='48.20,317.88 48.20,39.90 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='176.32,317.88 176.32,39.90 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='304.43,317.88 304.43,39.90 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='432.54,317.88 432.54,39.90 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='54.61,235.04 61.01,136.77 67.42,66.57 73.83,150.81 80.23,206.97 86.64,305.24 93.04,305.24 99.45,291.20 105.85,305.24 112.26,291.20 118.67,291.20 125.07,291.20 131.48,164.85 137.88,150.81 144.29,192.93 150.69,178.89 157.10,235.04 163.50,277.16 169.91,305.24 176.32,305.24 182.72,305.24 189.13,305.24 195.53,305.24 201.94,291.20 208.34,277.16 214.75,150.81 221.16,164.85 227.56,150.81 233.97,221.01 240.37,277.16 246.78,305.24 253.18,305.24 259.59,305.24 266.00,305.24 272.40,305.24 278.81,305.24 285.21,221.01 291.62,192.93 298.02,52.53 304.43,150.81 310.83,249.08 317.24,305.24 323.65,305.24 330.05,305.24 336.46,305.24 342.86,305.24 349.27,305.24 355.67,277.16 362.08,263.12 368.49,108.69 374.89,94.65 381.30,150.81 387.70,206.97 394.11,277.16 400.51,305.24 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<circle cx='54.61' cy='235.04' r='1.42' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='61.01' cy='136.77' r='1.42' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='67.42' cy='66.57' r='1.42' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='73.83' cy='150.81' r='1.43' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='80.23' cy='206.97' r='1.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='86.64' cy='305.24' r='1.54' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='93.04' cy='305.24' r='1.81' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='99.45' cy='291.20' r='2.66' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='105.85' cy='305.24' r='1.84' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='112.26' cy='291.20' r='1.56' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='118.67' cy='291.20' r='1.47' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='125.07' cy='291.20' r='1.44' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='131.48' cy='164.85' r='1.43' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='137.88' cy='150.81' r='1.42' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='144.29' cy='192.93' r='1.43' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='150.69' cy='178.89' r='1.44' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='157.10' cy='235.04' r='1.48' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='163.50' cy='277.16' r='1.61' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='169.91' cy='305.24' r='2.05' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='176.32' cy='305.24' r='3.44' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='182.72' cy='305.24' r='2.10' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='189.13' cy='305.24' r='1.65' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='195.53' cy='305.24' r='1.50' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='201.94' cy='291.20' r='1.45' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='208.34' cy='277.16' r='1.43' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='214.75' cy='150.81' r='1.42' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='221.16' cy='164.85' r='1.43' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='227.56' cy='150.81' r='1.45' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='233.97' cy='221.01' r='1.52' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='240.37' cy='277.16' r='1.74' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='246.78' cy='305.24' r='2.44' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='253.18' cy='305.24' r='4.70' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='259.59' cy='305.24' r='2.52' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='266.00' cy='305.24' r='1.79' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='272.40' cy='305.24' r='1.55' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='278.81' cy='305.24' r='1.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='285.21' cy='221.01' r='1.44' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='291.62' cy='192.93' r='1.43' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='298.02' cy='52.53' r='1.44' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='304.43' cy='150.81' r='1.47' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='310.83' cy='249.08' r='1.58' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='317.24' cy='305.24' r='1.93' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='323.65' cy='305.24' r='3.07' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='330.05' cy='305.24' r='6.76' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='336.46' cy='305.24' r='3.21' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='342.86' cy='305.24' r='2.02' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='349.27' cy='305.24' r='1.62' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='355.67' cy='277.16' r='1.49' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='362.08' cy='263.12' r='1.44' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='368.49' cy='108.69' r='1.43' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='374.89' cy='94.65' r='1.45' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='381.30' cy='150.81' r='1.50' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='387.70' cy='206.97' r='1.68' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='394.11' cy='277.16' r='2.25' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<circle cx='400.51' cy='305.24' r='4.11' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #000000;' />
+<polygon points='406.92,305.24 413.33,305.24 419.73,305.24 426.14,277.16 432.54,263.12 438.95,108.69 445.35,94.65 451.76,52.53 458.16,94.65 464.57,150.81 470.98,206.97 477.38,277.16 477.38,305.24 470.98,305.24 464.57,277.16 458.16,221.01 451.76,221.01 445.35,277.16 438.95,305.24 432.54,305.24 426.14,305.24 419.73,305.24 413.33,305.24 406.92,305.24 ' style='stroke-width: 0.00; stroke: none; fill: #0000FF; fill-opacity: 0.16;' />
+<polyline points='406.92,305.24 413.33,305.24 419.73,305.24 426.14,277.16 432.54,263.12 438.95,108.69 445.35,94.65 451.76,52.53 458.16,94.65 464.57,150.81 470.98,206.97 477.38,277.16 ' style='stroke-width: 1.07; stroke: none;' />
+<polyline points='477.38,305.24 470.98,305.24 464.57,277.16 458.16,221.01 451.76,221.01 445.35,277.16 438.95,305.24 432.54,305.24 426.14,305.24 419.73,305.24 413.33,305.24 406.92,305.24 ' style='stroke-width: 1.07; stroke: none;' />
+<polygon points='406.92,305.24 413.33,305.24 419.73,305.24 426.14,305.24 432.54,277.16 438.95,221.01 445.35,108.69 451.76,66.57 458.16,150.81 464.57,150.81 470.98,249.08 477.38,305.24 477.38,305.24 470.98,305.24 464.57,249.08 458.16,150.81 451.76,164.85 445.35,221.01 438.95,277.16 432.54,305.24 426.14,305.24 419.73,305.24 413.33,305.24 406.92,305.24 ' style='stroke-width: 0.00; stroke: none; fill: #0000FF; fill-opacity: 0.16;' />
+<polyline points='406.92,305.24 413.33,305.24 419.73,305.24 426.14,305.24 432.54,277.16 438.95,221.01 445.35,108.69 451.76,66.57 458.16,150.81 464.57,150.81 470.98,249.08 477.38,305.24 ' style='stroke-width: 1.07; stroke: none;' />
+<polyline points='477.38,305.24 470.98,305.24 464.57,249.08 458.16,150.81 451.76,164.85 445.35,221.01 438.95,277.16 432.54,305.24 426.14,305.24 419.73,305.24 413.33,305.24 406.92,305.24 ' style='stroke-width: 1.07; stroke: none;' />
+<polygon points='406.92,305.24 413.33,305.24 419.73,305.24 426.14,305.24 432.54,277.16 438.95,221.01 445.35,108.69 451.76,94.65 458.16,150.81 464.57,206.97 470.98,277.16 477.38,305.24 477.38,305.24 470.98,305.24 464.57,249.08 458.16,150.81 451.76,150.81 445.35,192.93 438.95,263.12 432.54,305.24 426.14,305.24 419.73,305.24 413.33,305.24 406.92,305.24 ' style='stroke-width: 0.00; stroke: none; fill: #0000FF; fill-opacity: 0.16;' />
+<polyline points='406.92,305.24 413.33,305.24 419.73,305.24 426.14,305.24 432.54,277.16 438.95,221.01 445.35,108.69 451.76,94.65 458.16,150.81 464.57,206.97 470.98,277.16 477.38,305.24 ' style='stroke-width: 1.07; stroke: none;' />
+<polyline points='477.38,305.24 470.98,305.24 464.57,249.08 458.16,150.81 451.76,150.81 445.35,192.93 438.95,263.12 432.54,305.24 426.14,305.24 419.73,305.24 413.33,305.24 406.92,305.24 ' style='stroke-width: 1.07; stroke: none;' />
+<polyline points='406.92,305.24 413.33,305.24 419.73,305.24 426.14,305.24 432.54,277.16 438.95,263.12 445.35,108.69 451.76,94.65 458.16,150.81 464.57,206.97 470.98,277.16 477.38,305.24 ' style='stroke-width: 1.07; stroke: #00008B; stroke-linecap: butt;' />
+<circle cx='406.92' cy='305.24' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
+<circle cx='413.33' cy='305.24' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
+<circle cx='419.73' cy='305.24' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
+<circle cx='426.14' cy='305.24' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
+<circle cx='432.54' cy='277.16' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
+<circle cx='438.95' cy='263.12' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
+<circle cx='445.35' cy='108.69' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
+<circle cx='451.76' cy='94.65' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
+<circle cx='458.16' cy='150.81' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
+<circle cx='464.57' cy='206.97' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
+<circle cx='470.98' cy='277.16' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
+<circle cx='477.38' cy='305.24' r='1.95' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #00008B;' />
 </g>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHwzNjAuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzMuNDd8NDk4LjUyfDUuNDh8MzkuOTA='>
+    <rect x='33.47' y='5.48' width='465.05' height='34.42' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzMuNDd8NDk4LjUyfDUuNDh8MzkuOTA=)'>
 </g>
 <defs>
   <clipPath id='cpMzMuNDd8NDk4LjUyfDUuNDh8MjIuNjk='>
@@ -136,6 +143,19 @@
 <rect x='33.47' y='5.48' width='465.05' height='17.21' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
 <text x='266.00' y='17.24' text-anchor='middle' style='font-size: 8.80px;fill: #1A1A1A; font-family: "Arial";' textLength='185.42px' lengthAdjust='spacingAndGlyphs'>alpha: 0.0778; seasonal: 0.8958; decay: 0.0016</text>
 </g>
+<g clip-path='url(#cpMzMuNDd8NDk4LjUyfDUuNDh8MzkuOTA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzMuNDd8NDk4LjUyfDIyLjY5fDM5Ljkw'>
+    <rect x='33.47' y='22.69' width='465.05' height='17.21' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzMuNDd8NDk4LjUyfDIyLjY5fDM5Ljkw)'>
+<rect x='33.47' y='22.69' width='465.05' height='17.21' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='266.00' y='34.45' text-anchor='middle' style='font-size: 8.80px;fill: #1A1A1A; font-family: "Arial";' textLength='110.50px' lengthAdjust='spacingAndGlyphs'>Is observation-driven: TRUE</text>
+</g>
+<g clip-path='url(#cpMzMuNDd8NDk4LjUyfDUuNDh8MzkuOTA=)'>
+</g>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHwzNjAuMDA=)'>
 <polyline points='48.20,320.62 48.20,317.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='176.32,320.62 176.32,317.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
@@ -145,15 +165,15 @@
 <text x='176.32' y='329.12' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
 <text x='304.43' y='329.12' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>40</text>
 <text x='432.54' y='329.12' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>60</text>
-<text x='28.54' y='307.61' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='28.54' y='233.07' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>5</text>
-<text x='28.54' y='158.53' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
-<text x='28.54' y='83.99' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
-<polyline points='30.73,304.46 33.47,304.46 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='30.73,229.92 33.47,229.92 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='30.73,155.37 33.47,155.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='30.73,80.83 33.47,80.83 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text transform='translate(13.37,170.28) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Arial";' textLength='28.14px' lengthAdjust='spacingAndGlyphs'>Value</text>
+<text x='28.54' y='308.39' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='28.54' y='238.20' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='28.54' y='168.00' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='28.54' y='97.80' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Arial";' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<polyline points='30.73,305.24 33.47,305.24 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.73,235.04 33.47,235.04 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.73,164.85 33.47,164.85 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.73,94.65 33.47,94.65 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text transform='translate(13.37,178.89) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Arial";' textLength='28.14px' lengthAdjust='spacingAndGlyphs'>Value</text>
 <text x='498.52' y='343.04' text-anchor='end' style='font-size: 8.80px; font-family: "Arial";' textLength='163.81px' lengthAdjust='spacingAndGlyphs'>Forecast intervals at 50%, 66%, and 92%.</text>
 <text x='498.52' y='352.54' text-anchor='end' style='font-size: 8.80px; font-family: "Arial";' textLength='382.92px' lengthAdjust='spacingAndGlyphs'>This corresponds to falling outside the interval for half of the year, once per quarter, once per year.</text>
 </g>

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -18,9 +18,16 @@ expect_threedx_paths <- function(forecast,
                                  observation_driven) {
   
   expect_class(x = forecast, classes = "threedx_paths")
-  expect_list(x = forecast, len = 2, names = "unique")
-  expect_names(x = names(forecast), identical.to = c("paths", "model"))
+  expect_list(x = forecast, min.len = 2, names = "unique")
+  expect_names(
+    x = names(forecast),
+    must.include = c("paths", "model", "horizon", "n_samples",
+                     "observation_driven")
+  )
   expect_identical(model, forecast$model)
+  expect_identical(horizon, forecast$horizon)
+  expect_identical(n_samples, forecast$n_samples)
+  expect_identical(observation_driven, forecast$observation_driven)
   
   expect_matrix(
     x = forecast$paths,


### PR DESCRIPTION
For plotting and analysis after fitting and predicting, it's useful to have the `observation_driven` argument be part of the `predict.threedx` object. This way, it can be rendered via the `autoplot()` methods, for example.