### PR TITLE
Add `postprocess` argument to `predict.threedx()`

### DIFF
--- a/man/predict.threedx.Rd
+++ b/man/predict.threedx.Rd
@@ -10,6 +10,7 @@
   n_samples,
   observation_driven,
   innovation_function,
+  postprocess = identity,
   ...
 )
 }
@@ -38,6 +39,16 @@ The provided \code{innovation_function} must return a numeric vector of length
 \code{n} that contains i.i.d samples that can be used for any sample path and
 forecast horizon.
 This argument is ignored when \code{observation_driven=TRUE}.}
+
+\item{postprocess}{A function that is applied on a numeric matrix of
+drawn samples for a single step-ahead before the samples are used to
+update the state of the model, and before outliers are removed
+(if applicable). By default equal to \code{identity()}, but could also
+be something like \code{function(x) pmax(x, 0)} to enforce a lower bound of 0,
+or any other transformation of interest that returns a numeric matrix of
+same dimensions as those of the input.
+Note that this can cause arbitrary errors caused by the author of the
+function provided to \code{postprocess}.}
 
 \item{...}{Additional arguments passed to \code{innovation_function}}
 }
@@ -79,6 +90,19 @@ forecast_latent <- predict(
 
 if (require("ggplot2")) {
   autoplot(forecast_latent)
+}
+
+forecast_latent_with_postprocessing <- predict(
+  object = model,
+  horizon = 12L,
+  n_samples = 2500L,
+  observation_driven = FALSE,
+  innovation_function = draw_normal_with_zero_mean,
+  postprocess = function(x) round(pmax(x, 0))
+)
+
+if (require("ggplot2")) {
+  autoplot(forecast_latent_with_postprocessing)
 }
 
 }

--- a/man/predict_with_observations.Rd
+++ b/man/predict_with_observations.Rd
@@ -2,11 +2,11 @@
 % Please edit documentation in R/predict.R
 \name{predict_with_observations}
 \alias{predict_with_observations}
-\title{Generate sample paths using observations}
+\title{Generate sample paths using observed values}
 \usage{
-predict_with_observations(y_m, object, horizon, n_samples)
+predict_with_observations(y_m, object, horizon, n_samples, postprocess)
 }
 \description{
-Generate sample paths using observations
+Generate sample paths using observed values
 }
 \keyword{internal}

--- a/man/predict_with_state.Rd
+++ b/man/predict_with_state.Rd
@@ -4,7 +4,15 @@
 \alias{predict_with_state}
 \title{Generate sample paths using latent state}
 \usage{
-predict_with_state(y_m, object, horizon, n_samples, innovation_function, ...)
+predict_with_state(
+  y_m,
+  object,
+  horizon,
+  n_samples,
+  innovation_function,
+  postprocess,
+  ...
+)
 }
 \description{
 Generate sample paths using latent state


### PR DESCRIPTION
Users can hook into the sample path generation process by providing a function to the `postprocess` argument. This way samples can be adjusted to conform to custom restrictions such as non-negativity.