### PR TITLE
Apply moving offset for residuals when time series are short

### DIFF
--- a/R/learn_weights.R
+++ b/R/learn_weights.R
@@ -65,8 +65,9 @@ learn_weights <- function(y,
   n <- length(y)
   
   offset <- period_length
-  if (n <= offset) {
-    offset <- 1
+  # use early residuals while time series is short compared to period length
+  if (n <= 2 * offset) {
+    offset <- max(1, n - period_length)
   }
   
   step_ahead_predictions <- matrix(

--- a/tests/testthat/test-learn_weights.R
+++ b/tests/testthat/test-learn_weights.R
@@ -201,8 +201,8 @@ expect_threedx <- function(model, y, period_length, alphas_grid) {
   n_params <- nrow(alphas_grid)
   
   n_initial_period <- period_length
-  if (n_obs <= period_length) {
-    n_initial_period <- 1
+  if (n_obs <= 2 * period_length) {
+    n_initial_period <- max(1, n_obs - period_length)
   }
   
   expect_numeric(x = model$fitted, all.missing = FALSE, len = n_obs)


### PR DESCRIPTION
Previously, the set of non-NA residuals dropped back down to 1 when a time series reached `period_length`-observations which lead to collapsed prediction intervals. Now, we keep using residuals from the initial observations until the time series has length of at least two periods. This is not ideal as the early residuals are not representative of the seasonal effects, but better than collapsed prediction intervals.