### PR TITLE
Robustify `draw_bootstrap()` for `errors` argument length of one

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -361,11 +361,17 @@ draw_normal_with_zero_mean <- function(n, errors, ...) {
 #' )
 draw_bootstrap_weighted <- function(n, errors, weight_function, ...) {
   checkmate::assert_integerish(x = n, lower = 1, any.missing = FALSE, len = 1)
-  checkmate::assert_numeric(x = errors, finite = TRUE, any.missing = FALSE)
+  checkmate::assert_numeric(
+    x = errors, finite = TRUE, any.missing = FALSE, min.len = 1
+  )
   checkmate::assert_function(
     x = weight_function,
     nargs = 1L
   )
+  
+  if (length(errors) == 1L) {
+    return(rep(errors, times = n))
+  }
   
   sample(x = errors, size = n, replace = TRUE, prob = weight_function(errors))
 }
@@ -398,6 +404,13 @@ draw_bootstrap_weighted <- function(n, errors, weight_function, ...) {
 #' 
 draw_bootstrap <- function(n, errors, ...) {
   checkmate::assert_integerish(x = n, lower = 1, any.missing = FALSE, len = 1)
-  checkmate::assert_numeric(x = errors, finite = TRUE, any.missing = FALSE)
+  checkmate::assert_numeric(
+    x = errors, finite = TRUE, any.missing = FALSE, min.len = 1
+  )
+  
+  if (length(errors) == 1L) {
+    return(rep(errors, times = n))
+  }
+  
   sample(x = errors, size = n, replace = TRUE, prob = NULL)
 }

--- a/tests/testthat/test-draw_bootstrap.R
+++ b/tests/testthat/test-draw_bootstrap.R
@@ -1,7 +1,7 @@
 n <- 2743
 errors <- 1:100
 
-test_that("generates same sequence as `sample()`", {
+test_that("generates same sequence as `sample()` for length larger 1 errors", {
   set.seed(7399)
   innovations <- draw_bootstrap(n = n, errors = errors)
   
@@ -9,6 +9,14 @@ test_that("generates same sequence as `sample()`", {
   expected <- sample(x = errors, size = n, replace = TRUE, prob = NULL)
   
   expect_equal(innovations, expected)
+})
+
+test_that("generates sequence based solely on errors of length 1", {
+  # `sample(x = 28, size = 50, replace = TRUE)` would fail this test
+  expect_equal(
+    draw_bootstrap(n = 50, errors = 28),
+    rep(28, times = 50)
+  )
 })
 
 test_that("fails when any `error` is missing", {
@@ -47,6 +55,10 @@ test_that("fails when `n` is not integerish", {
 
 test_that("fails when `n` is less than 1", {
   expect_error(draw_bootstrap(n = 0L, errors = errors))
+})
+
+test_that("fails when `errors` is of length less than 1", {
+  expect_error(draw_bootstrap(n = n, errors = numeric()))
 })
 
 test_that("fails when `errors` is not numeric vector", {

--- a/tests/testthat/test-draw_bootstrap_weighted.R
+++ b/tests/testthat/test-draw_bootstrap_weighted.R
@@ -18,6 +18,14 @@ test_that("generates same sequence as `sample()`", {
   expect_equal(innovations, expected)
 })
 
+test_that("generates sequence based solely on errors of length 1", {
+  # `sample(x = 28, size = 50, replace = TRUE)` would fail this test
+  expect_equal(
+    draw_bootstrap(n = 50, errors = 28, weight_function = weight_function),
+    rep(28, times = 50)
+  )
+})
+
 test_that("fails when any `error` is missing", {
   expect_error(
     draw_bootstrap_weighted(
@@ -74,6 +82,14 @@ test_that("fails when `n` is not integerish", {
 test_that("fails when `n` is less than 1", {
   expect_error(draw_bootstrap_weighted(
     n = 0L, errors = errors,
+    weight_function = weight_function
+  ))
+})
+
+test_that("fails when `errors` is of length less than 1", {
+  expect_error(draw_bootstrap_weighted(
+    n = n,
+    errors = numeric(),
     weight_function = weight_function
   ))
 })


### PR DESCRIPTION
As `sample()` turns a numeric `x` argument into `seq_len(x)` instead of interpreting it as a set with one unique value from which to draw samples, we add a special case that handles `errors` arguments of length one via a special case that returns `errors` directly.